### PR TITLE
GMR-1036: MTU fix

### DIFF
--- a/coapthon/client/coap.py
+++ b/coapthon/client/coap.py
@@ -252,7 +252,7 @@ class CoAP(object):
         while not self.stopped.isSet():
             self._socket.settimeout(0.1)
             try:
-                datagram, addr = self._socket.recvfrom(1152)
+                datagram, addr = self._socket.recvfrom(65535) # Max 64K Payload
             except socket.timeout:  # pragma: no cover
                 continue
             except Exception as e:  # pragma: no cover


### PR DESCRIPTION
    Action: RESOLVED
    
    Description:  The fix was in the client/coap.py file by modifying the
    recv function to allow up to 64K bytes.
    
    Testing: Able to get /.well-known/core without truncation via Colibri on
    the Iris carrier.
